### PR TITLE
Find and fix bugs

### DIFF
--- a/src/components/communication/DeveloperRealtimePanel.tsx
+++ b/src/components/communication/DeveloperRealtimePanel.tsx
@@ -17,21 +17,21 @@ export const DeveloperRealtimePanel: React.FC = () => {
 
   const simulateTyping = () => {
     if (!conversationId) return;
-    const otherUserId = useOtherParticipant(conversationId);
+    const otherUserId = getOtherParticipant(conversationId);
     if (!otherUserId) return;
     setTypingStatusInConversation(conversationId, otherUserId, true);
     setTimeout(() => setTypingStatusInConversation(conversationId, otherUserId, false), 1500);
   };
 
   const simulatePresence = () => {
-    const otherUserId = useOtherParticipant(conversationId);
+    const otherUserId = getOtherParticipant(conversationId);
     if (!conversationId || !otherUserId) return;
     setOnlineStatus(otherUserId, 0 as any); // OnlineStatus.ONLINE without import to keep lightweight
   };
 
   const simulateIncomingMessage = () => {
     if (!conversationId) return;
-    const otherUserId = useOtherParticipant(conversationId);
+    const otherUserId = getOtherParticipant(conversationId);
     if (!otherUserId) return;
     addMessage({
       id: `dev_${Date.now()}`,
@@ -82,7 +82,7 @@ export const DeveloperRealtimePanel: React.FC = () => {
   );
 };
 
-function useOtherParticipant(conversationId: string): string | null {
+function getOtherParticipant(conversationId: string): string | null {
   const { conversations } = useCommunicationStore.getState();
   const conv = conversations.find(c => c.id === conversationId);
   if (!conv) return null;

--- a/src/hooks/useFormValidation.ts
+++ b/src/hooks/useFormValidation.ts
@@ -1,6 +1,13 @@
 import { useForm, UseFormReturn } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import {
+  basicInfoSchema,
+  scheduleLocationSchema,
+  budgetRequirementsSchema,
+  applicationSchema,
+  locationSchema
+} from '../utils/validationSchemas';
 
 interface UseFormValidationOptions<T extends z.ZodType> {
   schema: T;
@@ -21,8 +28,7 @@ export function useFormValidation<T extends z.ZodType>({
 }
 
 // Specific hooks for job creation steps
-export function useBasicInfoValidation(defaultValues?: Partial<z.infer<typeof import('../utils/validationSchemas').basicInfoSchema>>) {
-  const { basicInfoSchema } = require('../utils/validationSchemas');
+export function useBasicInfoValidation(defaultValues?: Partial<z.infer<typeof basicInfoSchema>>) {
   return useFormValidation({
     schema: basicInfoSchema,
     defaultValues,
@@ -30,8 +36,7 @@ export function useBasicInfoValidation(defaultValues?: Partial<z.infer<typeof im
   });
 }
 
-export function useScheduleLocationValidation(defaultValues?: Partial<z.infer<typeof import('../utils/validationSchemas').scheduleLocationSchema>>) {
-  const { scheduleLocationSchema } = require('../utils/validationSchemas');
+export function useScheduleLocationValidation(defaultValues?: Partial<z.infer<typeof scheduleLocationSchema>>) {
   return useFormValidation({
     schema: scheduleLocationSchema,
     defaultValues,
@@ -39,8 +44,7 @@ export function useScheduleLocationValidation(defaultValues?: Partial<z.infer<ty
   });
 }
 
-export function useBudgetRequirementsValidation(defaultValues?: Partial<z.infer<typeof import('../utils/validationSchemas').budgetRequirementsSchema>>) {
-  const { budgetRequirementsSchema } = require('../utils/validationSchemas');
+export function useBudgetRequirementsValidation(defaultValues?: Partial<z.infer<typeof budgetRequirementsSchema>>) {
   return useFormValidation({
     schema: budgetRequirementsSchema,
     defaultValues,
@@ -48,8 +52,7 @@ export function useBudgetRequirementsValidation(defaultValues?: Partial<z.infer<
   });
 }
 
-export function useApplicationValidation(defaultValues?: Partial<z.infer<typeof import('../utils/validationSchemas').applicationSchema>>) {
-  const { applicationSchema } = require('../utils/validationSchemas');
+export function useApplicationValidation(defaultValues?: Partial<z.infer<typeof applicationSchema>>) {
   return useFormValidation({
     schema: applicationSchema,
     defaultValues,
@@ -57,8 +60,7 @@ export function useApplicationValidation(defaultValues?: Partial<z.infer<typeof 
   });
 }
 
-export function useLocationValidation(defaultValues?: Partial<z.infer<typeof import('../utils/validationSchemas').locationSchema>>) {
-  const { locationSchema } = require('../utils/validationSchemas');
+export function useLocationValidation(defaultValues?: Partial<z.infer<typeof locationSchema>>) {
   return useFormValidation({
     schema: locationSchema,
     defaultValues,

--- a/src/store/jobDiscoveryStore.ts
+++ b/src/store/jobDiscoveryStore.ts
@@ -137,18 +137,21 @@ export const useJobDiscoveryStore = create<JobDiscoveryStore>((set, get) => ({
       
       // Apply additional sorting
       switch (sortBy) {
-        case 'DATE':
+        case 'DATE': {
           filteredJobs.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
           break;
-        case 'BUDGET':
+        }
+        case 'BUDGET': {
           filteredJobs.sort((a, b) => b.budgetRange.max - a.budgetRange.max);
           break;
-        case 'URGENCY':
-          const urgencyOrder = { 'EMERGENCY': 3, 'URGENT': 2, 'NORMAL': 1 };
+        }
+        case 'URGENCY': {
+          const urgencyOrder = { 'EMERGENCY': 3, 'URGENT': 2, 'NORMAL': 1 } as const;
           filteredJobs.sort((a, b) => 
-            (urgencyOrder[b.urgency] || 0) - (urgencyOrder[a.urgency] || 0)
+            (urgencyOrder[b.urgency as keyof typeof urgencyOrder] || 0) - (urgencyOrder[a.urgency as keyof typeof urgencyOrder] || 0)
           );
           break;
+        }
         // DISTANCE is already handled above
       }
       


### PR DESCRIPTION
Fixes React Hooks misuse, illegal `require()` usage, and a switch/case scoping bug to resolve identified runtime and linting errors.

The `useOtherParticipant` hook was incorrectly called inside non-hook functions, leading to `react-hooks/rules-of-hooks` violations. CommonJS `require()` calls were used in an ESM context, causing `@typescript-eslint/no-require-imports` errors. Additionally, lexical declarations within `switch` case blocks without braces violated `no-case-declarations`. This PR addresses these three concrete issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-91a92af1-ad7b-4322-855a-ec2ec01d4adc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91a92af1-ad7b-4322-855a-ec2ec01d4adc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

